### PR TITLE
release: binary releases for Linux x86_64 and aarch64 with a one-line installer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,132 @@
+name: Release
+
+# A tag `vX.Y.Z` on master builds `kern` for Linux x86_64 and aarch64 in a
+# glibc 2.28 container, proves each binary starts there without a CUDA
+# toolkit, and publishes a GitHub release with the archives, one
+# SHA256SUMS, the installer, and build provenance. A pull request that
+# touches this pipeline runs the build and packaging, never the publish.
+# The GPU gate is manual and comes after: docs/release.md.
+
+on:
+  push:
+    tags: ["v*"]
+  pull_request:
+    paths:
+      - ".github/workflows/release.yml"
+      - "scripts/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-24.04
+          - target: aarch64-unknown-linux-gnu
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    # manylinux_2_28: glibc 2.28 and a current gcc, the floor the release
+    # promises (RHEL 8, Ubuntu 20.04 and everything newer).
+    container: quay.io/pypa/manylinux_2_28_${{ matrix.target == 'x86_64-unknown-linux-gnu' && 'x86_64' || 'aarch64' }}
+    timeout-minutes: 60
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Resolve version
+        id: version
+        run: |
+          set -euo pipefail
+          version=$(cargo pkgid -p kern-run | sed 's/.*[@#]//')
+          if [ "$GITHUB_REF_TYPE" = tag ] && [ "$GITHUB_REF_NAME" != "v$version" ]; then
+            echo "::error::tag $GITHUB_REF_NAME does not match workspace version $version"
+            exit 1
+          fi
+          echo "version=$version" >>"$GITHUB_OUTPUT"
+
+      - name: Build
+        run: cargo build --release --locked -p kern-run
+        env:
+          KERN_COMMIT: ${{ github.sha }}
+
+      - name: Package and check
+        run: scripts/package_release.sh "${{ steps.version.outputs.version }}" "${{ matrix.target }}" dist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: kern-${{ matrix.target }}
+          path: dist/*
+          if-no-files-found: error
+          retention-days: 3
+
+  publish:
+    name: Publish
+    if: github.ref_type == 'tag'
+    needs: build
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: kern-*
+          path: dist
+          merge-multiple: true
+
+      - name: Assemble assets
+        run: |
+          set -euo pipefail
+          cd dist
+          cat ./*.sha256 >SHA256SUMS
+          rm ./*.sha256
+          cp ../scripts/install.sh install.sh
+          sha256sum -c SHA256SUMS
+          ls -la
+
+      - uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: dist/*.tar.gz
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          set -euo pipefail
+          if gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "::error::release $GITHUB_REF_NAME exists; delete it and the tag to republish"
+            exit 1
+          fi
+          cat >notes.md <<EOF
+          Prebuilt \`kern\` for Linux x86_64 and aarch64, glibc 2.28 or newer. Needs an
+          NVIDIA driver that supports CUDA 13 (r580 or newer) and cuBLAS 13 on the loader
+          path; no toolkit, no Python.
+
+          Install the latest release, or this one with \`KERN_VERSION=$GITHUB_REF_NAME\`:
+
+              curl -fsSL https://kern-baa.pages.dev/install.sh | sh
+          EOF
+          gh release create "$GITHUB_REF_NAME" dist/* \
+            --repo "$GITHUB_REPOSITORY" \
+            --verify-tag \
+            --title "kern $VERSION" \
+            --notes-file notes.md \
+            --generate-notes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,9 @@ kern-manifest = { path = "crates/kern-manifest" }
 
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
-cudarc = { version = "=0.19.7", features = ["cuda-version-from-build-system", "f16"] }
+# The CUDA API kern binds is a fact about the binary, not about the build
+# machine: `cuda-13000` pins it, and no toolkit is needed to build.
+cudarc = { version = "=0.19.7", features = ["cuda-13000", "f16"] }
 half = "=2.7.1"
 safetensors = "=0.7.0"
 schemars = "1"

--- a/README.md
+++ b/README.md
@@ -79,6 +79,19 @@ The loop runs unattended. The engine goes back to being an engine.
 ## Try it
 
 ```bash
+curl -fsSL https://kern-baa.pages.dev/install.sh | sh   # Linux x86_64 / aarch64, one binary
+kern --version                                          # kern 0.1.0 (<commit>, cuda 13.0)
+```
+
+The binary links no CUDA library; it dlopens the driver and cuBLAS at
+first use, so it needs an NVIDIA driver for CUDA 13 (r580+) and cuBLAS 13
+on the loader path, nothing else. `KERN_VERSION=v0.1.0` pins a release,
+`KERN_INSTALL_DIR` picks the directory (default `~/.local/bin`). How a
+release is cut and gated: [docs/release.md](docs/release.md).
+
+Or from source:
+
+```bash
 cargo build --release
 
 # kern.toml at the repo root names the fixture target (manifest, reference,
@@ -116,7 +129,7 @@ golden-checked in CI:
 | `crates/kern-runtime` | The executor: fetch, verify, replay, CUDA graphs |
 | `crates/kern-run` | `kern run` (generation) and `kern test` (A/B evidence) over the example manifests |
 | `examples/` | Generated manifests — the artifact a provider ships (`*-silu-mined.json` is the attest fixture) |
-| `docs/` | [design](docs/design.md) · [manifest](docs/manifest.md) · [kernel mining](docs/kernel-mining.md) · [runtime](docs/runtime.md) · [attest](docs/attest.md) · [spec decode](docs/spec-decode.md) · [roadmap](docs/roadmap.md) |
+| `docs/` | [design](docs/design.md) · [manifest](docs/manifest.md) · [kernel mining](docs/kernel-mining.md) · [runtime](docs/runtime.md) · [attest](docs/attest.md) · [spec decode](docs/spec-decode.md) · [roadmap](docs/roadmap.md) · [release](docs/release.md) |
 
 **Website:** [kern-baa.pages.dev](https://kern-baa.pages.dev/)
 

--- a/crates/kern-run/build.rs
+++ b/crates/kern-run/build.rs
@@ -1,0 +1,22 @@
+//! Records the commit `kern` was built from, for `kern --version`.
+//!
+//! `git describe` on a checkout; `KERN_COMMIT` when set (a release build
+//! passes the tagged commit); `unknown` when neither is available (a crate
+//! built outside the repository).
+
+use std::process::Command;
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=KERN_COMMIT");
+    println!("cargo:rerun-if-changed=../../.git/HEAD");
+    println!("cargo:rerun-if-changed=../../.git/refs");
+    let commit =
+        std::env::var("KERN_COMMIT").ok().filter(|c| !c.is_empty()).or_else(describe).unwrap_or("unknown".into());
+    println!("cargo:rustc-env=KERN_COMMIT={commit}");
+}
+
+/// The short commit id, `-dirty` when the tree has uncommitted changes.
+fn describe() -> Option<String> {
+    let out = Command::new("git").args(["describe", "--always", "--dirty", "--exclude", "*"]).output().ok()?;
+    out.status.success().then(|| String::from_utf8_lossy(&out.stdout).trim().to_string())
+}

--- a/crates/kern-run/src/bin/kern.rs
+++ b/crates/kern-run/src/bin/kern.rs
@@ -18,7 +18,7 @@ use kern_run::run::RunOpts;
 #[derive(Parser)]
 #[command(
     name = "kern",
-    version,
+    version = kern_run::VERSION.as_str(),
     about = "model-agnostic GPU runtime: run a manifest, test a kernel swap, gather cubins, verify a manifest"
 )]
 struct Cli {

--- a/crates/kern-run/src/lib.rs
+++ b/crates/kern-run/src/lib.rs
@@ -15,12 +15,21 @@ pub mod config;
 pub mod run;
 
 use std::collections::BTreeMap;
+use std::sync::LazyLock;
 
 use anyhow::{ensure, Context, Result};
 use kern_manifest::protocol::{Axis, Forward, Rows};
 use kern_manifest::types::Fill;
 use kern_manifest::Protocol;
 use kern_runtime::{Lease, Runtime};
+
+/// What `kern --version` prints: the crate version, the commit it was built
+/// from, and the CUDA API the runtime binds; the three facts a bug report
+/// needs. The commit comes from `build.rs`.
+pub static VERSION: LazyLock<String> = LazyLock::new(|| {
+    let (major, minor) = (kern_runtime::CUDA_API / 1000, kern_runtime::CUDA_API % 1000 / 10);
+    format!("{} ({}, cuda {major}.{minor})", env!("CARGO_PKG_VERSION"), env!("KERN_COMMIT"))
+});
 
 /// What a checkpoint directory says besides its tensors: `tokenizer.json`
 /// and the ids that end generation (`generation_config.json`'s

--- a/crates/kern-runtime/src/lib.rs
+++ b/crates/kern-runtime/src/lib.rs
@@ -73,6 +73,11 @@ pub use host::{Host, Parked};
 pub use pages::{page_unit, Checkpoint, Copies, Denied, Lease, Pool, Pooled};
 pub use prefix::{Chain, Hit, Kept, Prefix, Tier};
 
+/// The CUDA API this binary binds (`13000` is 13.0): fixed by the `cudarc`
+/// feature at build time, so a driver older than it fails to load the
+/// libraries rather than at a random symbol later.
+pub const CUDA_API: u32 = sys::CUDA_VERSION;
+
 /// The host tier's block is handed out in these units.
 const HOST_GRAIN: u64 = 1 << 16;
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,84 @@
+# Release：怎么发一个 kern binary，什么时候算发完
+
+kern 的 release 是一个 binary：`kern`，Linux x86_64 与 aarch64 各一份，
+不含 CUDA 库（runtime 在首次使用时 dlopen driver 与 cuBLAS），不含 Python，
+不含模型。装完能跑什么由 manifest 决定，不在本页范围。
+
+流水线在 `.github/workflows/release.yml`，打包与自检在
+`scripts/package_release.sh`，安装脚本在 `scripts/install.sh`。
+
+## 用户看到的
+
+```bash
+curl -fsSL https://kern-baa.pages.dev/install.sh | sh
+kern --version          # kern 0.1.0 (<commit>, cuda 13.0)
+```
+
+- 网站的 `/install.sh` 是一条 302，指向最新 release 里的 `install.sh`；
+  脚本随每个 release 一起发，网站不另存一份。
+- 脚本下载 `kern-<target>.tar.gz` 与 `SHA256SUMS`，校验后装一个文件到
+  `~/.local/bin/kern`。`KERN_VERSION=v0.1.0` 钉版本，`KERN_INSTALL_DIR` 换目录，
+  `KERN_BASE_URL` 换下载源（镜像、离线包）。不 sudo，不改 shell rc，
+  不在 PATH 上时只打印一行 export。
+- 装完只 warn 不 fail 地说三件 `kern run` 会需要而它看不到的事：
+  driver 是否支持 CUDA 13（r580+）、cuBLAS 13 是否在 loader path 上、
+  找到了但不在 path 上时 `LD_LIBRARY_PATH` 该指哪。
+- 升级是重跑同一行，卸载是删一个文件。
+
+| 要求 | 值 |
+| --- | --- |
+| OS / arch | Linux x86_64、aarch64 |
+| glibc | ≥ 2.28（RHEL 8、Ubuntu 20.04 及更新） |
+| NVIDIA driver | 支持 CUDA 13（r580+） |
+| 运行时库 | `libcublas.so.13` / `libcublasLt.so.13` 在 loader path 上（toolkit，或 pip 的 `nvidia-cublas-cu13` 加 `LD_LIBRARY_PATH`） |
+
+## 流水线做什么
+
+1. **触发**：push 一个 `v*` tag。改到 workflow 或 `scripts/` 的 PR 也跑 build 与
+   打包（不 publish），所以流水线本身的改动在合并前就被 CI 验过。
+2. **构建**：两个 target 各自在 `manylinux_2_28` 容器里原生编（aarch64 用
+   GitHub 的 arm runner，不交叉）。cudarc 绑定的 CUDA 版本由 Cargo.toml 的
+   `cuda-13000` feature 钉死，构建机不装 toolkit；`KERN_COMMIT` 传 tag 的 commit。
+   tag 名必须等于 workspace version（`v` + `cargo pkgid`），不等就停。
+3. **自检**（`package_release.sh`，在构建容器里跑）：`kern --version` 报的版本 =
+   tag；`NEEDED` 里没有任何 CUDA 库；要的 glibc 符号版本 ≤ 2.28；
+   `kern verify examples/qwen3-4b.json` 跑通（无 GPU，证明 loader 在 2.28 上满足）。
+   任一条不过，release 不出。
+4. **发布**：合并两份 `.sha256` 成一份 `SHA256SUMS`，附上 `install.sh`，
+   对两个 tar.gz 做 GitHub build provenance attestation，`gh release create
+   --verify-tag`，notes 是固定的一段要求说明 + 自动生成的 commit 列表。
+   同名 release 已存在则拒绝，不覆盖资产。
+
+## 怎么发
+
+```bash
+# 1. bump：workspace version 在根 Cargo.toml 的 [workspace.package]
+git commit -am "release: v0.1.0"
+git push origin master
+# 2. tag
+git tag -a v0.1.0 -m "kern v0.1.0" && git push origin v0.1.0
+# 3. 看 Actions 的 Release 跑绿
+gh run watch
+```
+
+## 发完之后的 gate（手动，有 GPU 才能做）
+
+GitHub runner 没有 GPU，流水线只能证明 binary 起得来。release 发出后在一台
+空闲的 tray 上（先 `nvidia-smi`）：
+
+```bash
+curl -fsSL https://kern-baa.pages.dev/install.sh | sh
+kern --version                  # commit 与 tag 一致，cuda 13.0
+cd ~/kern-1 && kern test qwen3-4b   # 最后一行 PASS
+```
+
+三行都过，release 才算发完。不过就删掉 release 与 tag 重发，0.x 不做 hotfix 版本：
+
+```bash
+gh release delete v0.1.0 --yes --cleanup-tag
+```
+
+## 不做的
+
+macOS、Windows、musl（静态 musl 的 dlopen 不能用）、Homebrew、PyPI、docker 镜像、
+`kern-serve`（它拉整个 pegainfer 栈，只能在 kernel-lab 容器里编，另发）。

--- a/docs/site/getting-started/build-and-verify.md
+++ b/docs/site/getting-started/build-and-verify.md
@@ -25,10 +25,27 @@ examples/qwen3-4b.json: ok, 3 forwards, 6 fills
 This compiles only `kern-manifest`, the pure Rust parser and verifier used by
 the runtime.
 
+## Install the CLI
+
+Releases ship one binary for Linux x86_64 and aarch64 (glibc 2.28 or newer).
+It links no CUDA library and needs no toolkit or Python to install; at first
+use it loads the NVIDIA driver (CUDA 13, r580 or newer) and cuBLAS 13 from
+the loader path.
+
+```sh
+curl -fsSL https://kern-baa.pages.dev/install.sh | sh
+kern --version
+```
+
+`KERN_VERSION=v0.1.0` pins a release and `KERN_INSTALL_DIR` chooses the
+directory (default `~/.local/bin`). The script verifies the archive's
+checksum, installs one file, and warns about a missing driver or cuBLAS
+without failing.
+
 ## Build the complete CLI
 
-The complete workspace also requires an NVIDIA CUDA development toolkit whose
-version is supported by the pinned `cudarc` dependency.
+The CUDA API the runtime binds is fixed by the pinned `cudarc` feature, so
+building needs Rust and a C++ compiler but no CUDA toolkit.
 
 ```sh
 cargo build --release

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,104 @@
+#!/bin/sh
+# Install the kern binary from a GitHub release.
+#
+#   curl -fsSL https://kern-baa.pages.dev/install.sh | sh
+#
+#   KERN_VERSION      release tag to install (default: latest)
+#   KERN_INSTALL_DIR  where the binary goes (default: ~/.local/bin)
+#   KERN_BASE_URL     where the release assets are (default: GitHub releases)
+#
+# Downloads kern-<arch>-unknown-linux-gnu.tar.gz and its checksum, verifies,
+# installs one file. Nothing else is written. Then it looks at the machine
+# and says what `kern run` will need that it cannot see, without failing.
+set -eu
+
+repo=pegainfer-project/kern
+version=${KERN_VERSION:-latest}
+dir=${KERN_INSTALL_DIR:-$HOME/.local/bin}
+
+say() { printf 'kern install: %s\n' "$*"; }
+warn() { printf 'kern install: warning: %s\n' "$*" >&2; }
+die() { printf 'kern install: %s\n' "$*" >&2; exit 1; }
+
+[ "$(uname -s)" = Linux ] || die "kern runs on Linux only (this is $(uname -s))"
+case $(uname -m) in
+  x86_64) target=x86_64-unknown-linux-gnu ;;
+  aarch64 | arm64) target=aarch64-unknown-linux-gnu ;;
+  *) die "no release for $(uname -m); build from source: cargo install --git https://github.com/$repo kern-run" ;;
+esac
+
+if [ -n "${KERN_BASE_URL:-}" ]; then
+  base=$KERN_BASE_URL
+elif [ "$version" = latest ]; then
+  base=https://github.com/$repo/releases/latest/download
+else
+  base=https://github.com/$repo/releases/download/$version
+fi
+
+if command -v curl >/dev/null; then
+  fetch() { curl -fsSL -o "$2" "$1"; }
+elif command -v wget >/dev/null; then
+  fetch() { wget -qO "$2" "$1"; }
+else
+  die "need curl or wget"
+fi
+if command -v sha256sum >/dev/null; then
+  digest() { sha256sum "$1" | cut -d' ' -f1; }
+elif command -v shasum >/dev/null; then
+  digest() { shasum -a 256 "$1" | cut -d' ' -f1; }
+else
+  die "need sha256sum or shasum"
+fi
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+asset=kern-$target.tar.gz
+
+say "downloading $base/$asset"
+fetch "$base/$asset" "$tmp/$asset" || die "download failed; is $version a release with a $target build?"
+fetch "$base/SHA256SUMS" "$tmp/SHA256SUMS" || die "download of SHA256SUMS failed"
+want=$(awk -v a="$asset" '$2 == a {print $1}' "$tmp/SHA256SUMS")
+[ -n "$want" ] || die "SHA256SUMS has no entry for $asset"
+have=$(digest "$tmp/$asset")
+[ "$have" = "$want" ] || die "checksum mismatch for $asset: expected $want, got $have"
+
+tar -xzf "$tmp/$asset" -C "$tmp"
+mkdir -p "$dir"
+install -m 0755 "$tmp/kern" "$dir/kern"
+say "installed $("$dir/kern" --version) to $dir/kern"
+
+case ":$PATH:" in
+  *":$dir:"*) ;;
+  *) say "add it to PATH:  export PATH=\"$dir:\$PATH\"" ;;
+esac
+
+# What the runtime will dlopen at first use; say now what is missing.
+if ! command -v nvidia-smi >/dev/null; then
+  warn "no nvidia-smi on PATH; kern needs an NVIDIA driver that supports CUDA 13 (r580 or newer)"
+else
+  driver=$(nvidia-smi --query-gpu=driver_version --format=csv,noheader 2>/dev/null | head -1)
+  case ${driver%%.*} in
+    '' | *[!0-9]*) warn "could not read the driver version from nvidia-smi" ;;
+    *) [ "${driver%%.*}" -ge 580 ] || warn "driver $driver is older than r580; kern binds CUDA 13" ;;
+  esac
+fi
+
+on_loader_path() {
+  (ldconfig -p 2>/dev/null || true) | grep -q "$1" && return 0
+  IFS=:
+  for d in ${LD_LIBRARY_PATH:-}; do
+    [ -n "$d" ] && [ -e "$d/$1" ] && return 0
+  done
+  return 1
+}
+if ! on_loader_path libcublasLt.so.13; then
+  hint=
+  for d in /usr/local/cuda/lib64 /usr/local/cuda/targets/*/lib /usr/local/cuda-13*/lib64; do
+    [ -e "$d/libcublasLt.so.13" ] && { hint=$d; break; }
+  done
+  if [ -n "$hint" ]; then
+    warn "cuBLAS 13 is in $hint but not on the loader path:  export LD_LIBRARY_PATH=\"$hint:\${LD_LIBRARY_PATH:-}\""
+  else
+    warn "no cuBLAS 13 on the loader path; install the CUDA 13 toolkit, or pip install nvidia-cublas-cu13 and point LD_LIBRARY_PATH at its lib/"
+  fi
+fi

--- a/scripts/package_release.sh
+++ b/scripts/package_release.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Package a built `kern` for a GitHub release and prove it will start on
+# the machines the release promises: glibc 2.28, no CUDA library linked
+# (the runtime dlopens them), the version the tag says.
+#
+#   scripts/package_release.sh VERSION TARGET OUT_DIR
+#
+# Reads target/release/kern (or $KERN_BIN); writes
+# OUT_DIR/kern-TARGET.tar.gz and OUT_DIR/kern-TARGET.tar.gz.sha256. Run it
+# where the binary was built; the checks run the binary.
+set -euo pipefail
+
+[[ $# -eq 3 ]] || { echo "usage: $0 VERSION TARGET OUT_DIR" >&2; exit 2; }
+version=${1#v}
+target=$2
+out=$3
+root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+bin=${KERN_BIN:-$root/target/release/kern}
+glibc_max=2.28
+asset=kern-$target
+
+fail() { echo "package: $*" >&2; exit 1; }
+
+[[ -x $bin ]] || fail "no binary at $bin"
+
+# The version the binary reports is the version the tag names.
+reported=$("$bin" --version | awk '{print $2}')
+[[ $reported == "$version" ]] || fail "binary reports $reported, release is $version"
+
+# Nothing CUDA is a link-time dependency; the loader must not need a toolkit.
+needed=$(objdump -p "$bin" | awk '$1 == "NEEDED" {print $2}')
+if grep -Eq 'libcu|libnv' <<<"$needed"; then
+  fail "binary links a CUDA library:"$'\n'"$needed"
+fi
+
+# Every glibc symbol version the binary asks for is at most $glibc_max.
+asked=$(objdump -T "$bin" | grep -o 'GLIBC_[0-9.]*' | sed 's/GLIBC_//' | sort -Vu | tail -1)
+[[ $(printf '%s\n%s\n' "$asked" "$glibc_max" | sort -V | tail -1) == "$glibc_max" ]] ||
+  fail "binary needs glibc $asked, release promises $glibc_max"
+
+# A GPU-free command runs end to end: the loader is satisfied here.
+"$bin" verify "$root/examples/qwen3-4b.json" >/dev/null
+
+stage=$(mktemp -d)
+trap 'rm -rf -- "$stage"' EXIT
+install -m 0755 "$bin" "$stage/kern"
+mkdir -p "$out"
+tar -C "$stage" -czf "$out/$asset.tar.gz" kern
+(cd "$out" && sha256sum "$asset.tar.gz" >"$asset.tar.gz.sha256")
+echo "$out/$asset.tar.gz"

--- a/website/public/_redirects
+++ b/website/public/_redirects
@@ -1,0 +1,1 @@
+/install.sh https://github.com/pegainfer-project/kern/releases/latest/download/install.sh 302


### PR DESCRIPTION
## What

A release pipeline for the `kern` binary. Push a `vX.Y.Z` tag and GitHub builds `kern` for Linux x86_64 and aarch64, checks each binary, and publishes a release. Users install with one line.

```bash
curl -fsSL https://kern-baa.pages.dev/install.sh | sh
kern --version     # kern 0.1.0 (<commit>, cuda 13.0)
```

## Decisions

- **cudarc pinned to `cuda-13000`.** The CUDA API kern binds was whatever nvcc the build machine had. Now it is a fact in Cargo.toml, and building needs no toolkit at all (GitHub's plain runners build it).
- **glibc 2.28 floor.** Both targets build natively inside `manylinux_2_28` containers (aarch64 on `ubuntu-24.04-arm`, no cross-compiling). The packaging script refuses a binary that asks for a newer glibc symbol, links any CUDA library, reports a version other than the tag's, or fails `kern verify` on that container.
- **Install is one file, checksum-verified, no sudo.** `~/.local/bin/kern` by default; `KERN_VERSION`, `KERN_INSTALL_DIR`, `KERN_BASE_URL` override. After installing it warns (never fails) about what the runtime will dlopen and cannot see yet: a driver for CUDA 13, cuBLAS 13 on the loader path.
- **The site serves `/install.sh` as a 302** to the latest release's copy. The script ships with every release; nothing is maintained twice.
- **The GPU gate is manual and after the release**: install on a tray, `kern --version`, `kern test qwen3-4b` PASS. `docs/release.md` has the cut and the gate.
- Not in scope: kern-serve, macOS/Windows/musl, Homebrew, PyPI, docker.

## Verified

- Full build + packaging inside `manylinux_2_28_aarch64` locally: 4.7 MB archive, max GLIBC symbol 2.28, `NEEDED` has no CUDA lib, `kern verify` runs.
- Build with an empty PATH (no nvcc) in the lab container succeeds; `kern --version` prints `kern 0.1.0 (d416125-dirty, cuda 13.0)`.
- `install.sh` against a local HTTP server: plain, `curl | sh`, and a tampered SHA256SUMS (rejected with expected/got).
- shellcheck (both scripts) and actionlint clean; `cargo fmt --check`, clippy `-D warnings` on kern-runtime/kern-run, kern-manifest tests pass.
- This PR touches the pipeline's paths, so the Release workflow runs its build and packaging jobs here (publish is tag-only).

## Notes for after merge

- The `/install.sh` redirect 404s until the first tag exists. First cut: bump nothing (workspace is already 0.1.0), `git tag -a v0.1.0 && git push origin v0.1.0`.
- The repo has no LICENSE file; a binary release without one is worth fixing before `v0.1.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013w8zrh3noubRTjaHoc27dF
