### PR TITLE
ci: hawk denies unnecessary restricted visibility

### DIFF
--- a/.claude/skills/hawk/SKILL.md
+++ b/.claude/skills/hawk/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: hawk
+description: Audit or tighten Rust visibility with cargo-hawk (astral-sh/hawk); use when asked to run hawk, find dead or over-public items, or when the CI hawk job fails.
+---
+
+# hawk
+
+Workspace-wide `pub` lint. Closed-world: it starts from the `kern` binary and
+reports what nobody reaches. Three lints: `hawk::dead_public` (unused `pub`),
+`hawk::unnecessary_public` (only used inside its crate, could be `pub(crate)`),
+`hawk::unnecessary_restricted_visibility` (`pub(crate)`/`pub(super)` that could
+be private).
+
+## Run
+
+Needs the exact rustc it was built against (0.1.14 ↔ 1.98.1; bump both together,
+in `.github/workflows/ci.yml` too).
+
+```sh
+rustup toolchain install 1.98.1 --profile minimal
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/hawk/releases/download/0.1.14/cargo-hawk-installer.sh | sh
+cargo +1.98.1 hawk check                      # everything, ~30 s
+cargo +1.98.1 hawk check --output-format json # for scripting
+```
+
+CI enforces only the restricted-visibility class:
+
+```sh
+cargo +1.98.1 hawk check -A hawk::dead_public -A hawk::unnecessary_public -D hawk::unnecessary_restricted_visibility
+```
+
+## The one thing to know
+
+`crates/kern-serve` is outside the workspace and drives the runtime through
+its public API (`Runtime::lease_slot`, `retire`, `landed`, `pages_used`, …).
+Hawk cannot see it, so most `dead_public` / `unnecessary_public` findings in
+kern-runtime, kern-run and kern-manifest are that API. Before trusting a
+finding, grep the item in `crates/kern-serve/src`. Anything kern-serve uses
+stays `pub`.
+
+Never run `--fix` here: it would privatise kern-serve's API.
+
+Fix by hand, then confirm kern-serve still builds (kernel-lab container) and
+the CI command above is clean.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,3 +82,38 @@ jobs:
             echo "::error::schema/manifest-v4.schema.json is stale — regenerate with: cargo run -p kern-manifest --example gen_schema > schema/manifest-v4.schema.json"
             exit 1
           fi
+
+  hawk:
+    # Workspace-wide visibility lint. Only `unnecessary_restricted_visibility`
+    # is enforced: kern-serve lives outside this workspace and is the main
+    # consumer of the runtime's public API, so hawk's closed world would call
+    # that API dead. A `pub(crate)` cannot cross a crate boundary, so that
+    # class is exact. The other two lints are an audit tool; see the
+    # `hawk` skill. Hawk is built against one exact rustc; bump both together.
+    runs-on: ubuntu-latest
+    env:
+      HAWK_VERSION: "0.1.14"
+      HAWK_RUST: "1.98.1"
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.98.1
+
+      - name: Install cargo-hawk
+        run: |
+          set -euo pipefail
+          base="https://github.com/astral-sh/hawk/releases/download/$HAWK_VERSION"
+          curl -fsSL "$base/cargo-hawk-x86_64-unknown-linux-gnu.tar.gz" -o hawk.tar.gz
+          curl -fsSL "$base/cargo-hawk-x86_64-unknown-linux-gnu.tar.gz.sha256" -o hawk.sha256
+          echo "$(cut -d' ' -f1 hawk.sha256)  hawk.tar.gz" | sha256sum -c
+          tar -xzf hawk.tar.gz --strip-components=1 -C "$HOME/.cargo/bin" \
+            --wildcards "*/cargo-hawk" "*/cargo-hawk-driver"
+          cargo hawk --version
+
+      - name: Restricted visibility is the tightest that compiles
+        run: |
+          cargo +"$HAWK_RUST" hawk check --color always \
+            -A hawk::dead_public -A hawk::unnecessary_public \
+            -D hawk::unnecessary_restricted_visibility

--- a/crates/kern-runtime/src/chunks.rs
+++ b/crates/kern-runtime/src/chunks.rs
@@ -91,7 +91,7 @@ impl Chunks {
 
     /// Positions of each arena.
     #[cfg(test)]
-    pub(crate) fn positions(&self) -> Vec<usize> {
+    fn positions(&self) -> Vec<usize> {
         self.arenas.iter().map(|a| a.chunk.len()).collect()
     }
 

--- a/crates/kern-runtime/src/compile.rs
+++ b/crates/kern-runtime/src/compile.rs
@@ -42,7 +42,7 @@ impl CExpr {
     }
 
     /// Mark the vars this expression reads.
-    pub(crate) fn mark(&self, used: &mut [bool]) {
+    fn mark(&self, used: &mut [bool]) {
         match self {
             CExpr::Const(_) => {}
             CExpr::Var(i) => used[*i] = true,
@@ -80,9 +80,9 @@ pub(crate) enum Slot {
 /// literals and descriptors are finished at load; var-dependent fields are
 /// evaluated per run.
 pub(crate) struct PackPlan {
-    pub(crate) size: usize,
-    pub(crate) fields: Vec<(usize, usize, Slot)>,
-    pub(crate) maps: Vec<(usize, TmaBlob)>,
+    size: usize,
+    fields: Vec<(usize, usize, Slot)>,
+    maps: Vec<(usize, TmaBlob)>,
 }
 
 impl PackPlan {
@@ -105,7 +105,7 @@ impl PackPlan {
 }
 
 /// A `CUtensorMap` image, copied into a pack image at its (64-byte aligned) field offset.
-pub(crate) struct TmaBlob(pub(crate) [u8; 128]);
+pub(crate) struct TmaBlob([u8; 128]);
 
 pub(crate) enum LaunchKind {
     Cubin {

--- a/crates/kern-runtime/src/cubin.rs
+++ b/crates/kern-runtime/src/cubin.rs
@@ -347,7 +347,7 @@ fn find_cuobjdump() -> Option<PathBuf> {
 /// opcode carries `.MULTICAST`. Every `Function : <sym>` block is a
 /// function; a symbol appearing in several containers (same-name Triton
 /// instances) accumulates, so one bad instance taints the name.
-pub(crate) fn multicast_by_function(text: &str) -> BTreeMap<String, Vec<String>> {
+fn multicast_by_function(text: &str) -> BTreeMap<String, Vec<String>> {
     let mut out: BTreeMap<String, Vec<String>> = BTreeMap::new();
     let mut cur: Option<String> = None;
     for line in text.lines() {

--- a/crates/kern-runtime/src/device.rs
+++ b/crates/kern-runtime/src/device.rs
@@ -122,7 +122,7 @@ fn none_handle_type() -> sys::CUmemAllocationHandleType {
 
 /// Whether the device can hand out fabric handles (`cuMemCreate` with
 /// `CU_MEM_HANDLE_TYPE_FABRIC`).
-pub(crate) fn fabric_supported(dev: i32) -> Result<bool> {
+fn fabric_supported(dev: i32) -> Result<bool> {
     let mut v: i32 = 0;
     cuda_check(
         unsafe {
@@ -507,7 +507,7 @@ impl Drop for Physical {
 /// The shell of the pool's remaps: arenas in the pool's order over one set
 /// of physical chunks. Arenas drop first, then the chunks.
 pub(crate) struct Mapper {
-    pub(crate) arenas: Vec<Arena>,
+    arenas: Vec<Arena>,
     #[allow(dead_code)]
     physical: Physical,
 }


### PR DESCRIPTION
Adds [astral-sh/hawk](https://github.com/astral-sh/hawk) 0.1.14 as a CI job and fixes the nine findings it has today.

**Why only one of its three lints.** hawk is a closed-world analysis rooted at the `kern` binary. `crates/kern-serve` is outside the workspace and is the main consumer of the runtime's public API, so hawk calls that API dead: on master, 14 of 16 `dead_public` and about 110 of 172 `unnecessary_public` findings are kern-serve's. `unnecessary_restricted_visibility` is exact, because a `pub(crate)` cannot cross a crate boundary. That is what CI denies. The other two stay an audit tool; `.claude/skills/hawk` says how to read them and why `--fix` must never run in this repo.

**Pinning.** hawk uses `rustc_private` and only runs on the rustc it was built against (0.1.14 ↔ 1.98.1). The job downloads the release tarball, checks its sha256 and installs the two binaries; the version and toolchain move together.

**Gate.** Local: `cargo +1.98.1 hawk check -A hawk::dead_public -A hawk::unnecessary_public -D hawk::unnecessary_restricted_visibility` reports 0 findings after the runtime commit; clippy, tests and fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011gx2qCRJKiKHGejgh7GtEK