### PR TITLE
ci: the runtime's clippy and host-side tests run on every push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,11 +44,15 @@ jobs:
 
       - uses: mozilla-actions/sccache-action@v0.0.9
 
-      - name: Clippy kern-manifest
-        run: cargo clippy -p kern-manifest --all-targets -- -D warnings
+      - name: Clippy
+        # kern-serve builds only in the kernel-lab container; every other crate
+        # compiles here, cudarc loads libcuda at run time.
+        run: cargo clippy -p kern-manifest -p kern-runtime -p kern-run --all-targets -- -D warnings
 
-      - name: Test kern-manifest
-        run: cargo test -p kern-manifest
+      - name: Test
+        # The runtime's tests are host-side (Pool, Prefix, Host, values); the
+        # GPU gate is `kern test`.
+        run: cargo test -p kern-manifest -p kern-runtime
 
       - name: Performance evidence regression tests
         run: python3 -m unittest discover -s tools -p test_profile.py

--- a/crates/kern-runtime/examples/k3_moe_bench.rs
+++ b/crates/kern-runtime/examples/k3_moe_bench.rs
@@ -73,7 +73,7 @@ impl Routing {
             Routing::Narrow(k)
         } else if let Some(p) = s.strip_prefix("file:") {
             let bytes = std::fs::read(p).expect("routing file");
-            let ids: Vec<i32> = bytes.chunks_exact(4).map(|c| i32::from_le_bytes(c.try_into().unwrap())).collect();
+            let ids: Vec<i32> = bytes.as_chunks::<4>().0.iter().map(|c| i32::from_le_bytes(*c)).collect();
             assert!(ids.len().is_multiple_of(TOPK) && ids.iter().all(|&e| (0..EXPERTS as i32).contains(&e)));
             Routing::File(Arc::new(ids))
         } else {

--- a/crates/kern-runtime/examples/k3_moe_ep.rs
+++ b/crates/kern-runtime/examples/k3_moe_ep.rs
@@ -48,7 +48,7 @@ fn read_inputs(path: &Path) -> Inputs {
     let (_, meta) = safetensors::SafeTensors::read_metadata(&bytes).unwrap();
     let md = meta.metadata().clone().unwrap_or_default();
     let t = |n: &str| st.tensor(n).unwrap_or_else(|_| panic!("tensor {n}")).data().to_vec();
-    let y_ref: Vec<f32> = t("y_ref").chunks_exact(4).map(|c| f32::from_le_bytes(c.try_into().unwrap())).collect();
+    let y_ref: Vec<f32> = t("y_ref").as_chunks::<4>().0.iter().map(|c| f32::from_le_bytes(*c)).collect();
     Inputs {
         x: t("x"),
         topk_idx: t("topk_idx"),
@@ -60,7 +60,7 @@ fn read_inputs(path: &Path) -> Inputs {
 }
 
 fn bf16_to_f32(b: &[u8]) -> Vec<f32> {
-    b.chunks_exact(2).map(|c| f32::from_bits((u16::from_le_bytes([c[0], c[1]]) as u32) << 16)).collect()
+    b.as_chunks::<2>().0.iter().map(|c| f32::from_bits((u16::from_le_bytes(*c) as u32) << 16)).collect()
 }
 
 /// Load, stage inputs for rows [row0, row0 + rows), run once, return y rows


### PR DESCRIPTION
kern-runtime's 46 tests (35 integration tests in `tests/`, 11 unit tests) and kern-run's clippy ran only in the kernel-lab container until now. They need no GPU: the tests are host-side (`Pool`, `Prefix`, `Host`, `values`) and cudarc loads libcuda at run time, so the crates compile on ubuntu-latest.

kern-serve stays out of CI: it builds only inside the container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tf5zsBkBeTt7aVqPoC2KuM