### PR TITLE
hawk: a pub item is one reached from outside its crate

### DIFF
--- a/crates/kern-manifest/src/protocol.rs
+++ b/crates/kern-manifest/src/protocol.rs
@@ -146,7 +146,7 @@ pub struct Forward {
 impl Forward {
     /// Whether the program accepts a call of `groups` sequences of `rows`
     /// with no run among them.
-    pub fn accepts(&self, groups: u64, rows: Rows) -> bool {
+    fn accepts(&self, groups: u64, rows: Rows) -> bool {
         !self.span && self.rows == rows && groups <= self.groups
     }
 }

--- a/crates/kern-manifest/src/types.rs
+++ b/crates/kern-manifest/src/types.rs
@@ -28,7 +28,7 @@ use std::marker::PhantomData;
 use std::str::FromStr;
 
 /// The one format this crate reads and writes.
-pub const SCHEMA_VERSION: u32 = 4;
+pub(crate) const SCHEMA_VERSION: u32 = 4;
 
 /// Deserialize a JSON object into a map, rejecting duplicate keys (plain
 /// serde silently keeps the last one).
@@ -309,10 +309,10 @@ pub struct Segment {
 pub struct Domain {
     /// Inclusive lower bound, e.g. `0`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub min: Option<Bound>,
+    pub(crate) min: Option<Bound>,
     /// Inclusive upper bound, a literal or a var expression, e.g. `"tokens"`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub max: Option<Bound>,
+    pub(crate) max: Option<Bound>,
     /// Buffer or state whose rows / token slots the elements index, e.g. `"model.embed_tokens.weight"`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub index_into: Option<String>,
@@ -321,7 +321,7 @@ pub struct Domain {
     pub stride: u64,
     /// Require a non-decreasing sequence, e.g. `cu_seqlens`.
     #[serde(default, skip_serializing_if = "is_false")]
-    pub monotone: bool,
+    pub(crate) monotone: bool,
 }
 
 fn one() -> u64 {
@@ -344,7 +344,7 @@ pub enum Bound {
 }
 
 impl Bound {
-    pub fn eval(&self, vars: &BTreeMap<String, u64>) -> Result<f64, EvalError> {
+    pub(crate) fn eval(&self, vars: &BTreeMap<String, u64>) -> Result<f64, EvalError> {
         Ok(match self {
             Bound::Int(v) => *v as f64,
             Bound::Float(v) => *v,
@@ -485,7 +485,7 @@ impl DType {
         }
     }
 
-    pub fn as_str(self) -> &'static str {
+    fn as_str(self) -> &'static str {
         match self {
             DType::Bf16 => "bf16",
             DType::F16 => "f16",
@@ -764,7 +764,7 @@ pub struct KernelLaunch {
     pub entry: String,
     /// This launch's own ABI when it differs from the op's params, e.g. `["in buffer<bf16>", "out buffer<f32>", "i32"]`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub params: Option<Vec<ParamType>>,
+    params: Option<Vec<ParamType>>,
     /// Threads per block, e.g. `[1024, 1, 1]`.
     pub block: [u32; 3],
     /// Blocks per launch, as expressions, e.g. `[{"ceil_div": ["tokens", 128]}, 1, 1]`.
@@ -780,7 +780,7 @@ pub struct KernelLaunch {
     pub pdl: bool,
     /// Where each launch param comes from (default: the op's params in order), e.g. `[{"param": 0}, {"scratch": "pmax"}, {"i32": 64}]`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub args: Option<Vec<LaunchArg>>,
+    args: Option<Vec<LaunchArg>>,
 }
 
 /// A runtime built-in launch, e.g. `{"entry": "extern:cublaslt_bf16_tn"}`.
@@ -791,14 +791,14 @@ pub struct ExternLaunch {
     pub entry: String,
     /// This launch's own ABI when it differs from the op's params.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub params: Option<Vec<ParamType>>,
+    params: Option<Vec<ParamType>>,
     /// Where each launch param comes from (default: the op's params in order).
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub args: Option<Vec<LaunchArg>>,
+    args: Option<Vec<LaunchArg>>,
 }
 
 impl Launch {
-    pub fn is_extern(&self) -> bool {
+    pub(crate) fn is_extern(&self) -> bool {
         matches!(self, Launch::Extern(_))
     }
 
@@ -928,7 +928,7 @@ pub enum FieldSrc {
 impl Field {
     /// The field's width: explicit, else the source's natural width
     /// (`None` for a param source, whose width is the param's).
-    pub fn natural_width(&self) -> Option<u32> {
+    fn natural_width(&self) -> Option<u32> {
         self.width.or(match &self.src {
             FieldSrc::Param { .. } => None,
             FieldSrc::Scratch { .. } | FieldSrc::I64 { .. } => Some(8),
@@ -946,7 +946,7 @@ impl Field {
 impl Pack {
     /// Structural diagnostics: every field inside the image and no two
     /// overlapping. `width_of` supplies a param field's width.
-    pub fn check(&self, width_of: impl Fn(usize) -> Option<u32>) -> Vec<String> {
+    pub(crate) fn check(&self, width_of: impl Fn(usize) -> Option<u32>) -> Vec<String> {
         let mut errs = Vec::new();
         let mut spans: Vec<(u32, u32, usize)> = Vec::new();
         for (i, f) in self.fields.iter().enumerate() {
@@ -1039,7 +1039,7 @@ pub enum TmaDType {
 
 impl TmaDType {
     /// Element size in bits.
-    pub fn bits(self) -> u64 {
+    fn bits(self) -> u64 {
         match self {
             TmaDType::U4 => 4,
             TmaDType::U8 => 8,
@@ -1053,7 +1053,7 @@ impl TmaDType {
 impl TensorMap {
     /// Structural checks that need no buffer: rank, box limits, stride and
     /// swizzle alignment. Returns every violation.
-    pub fn check(&self) -> Vec<String> {
+    pub(crate) fn check(&self) -> Vec<String> {
         let mut errs = Vec::new();
         let n = self.dims.len();
         if !(1..=5).contains(&n) {

--- a/crates/kern-run/src/bench.rs
+++ b/crates/kern-run/src/bench.rs
@@ -22,47 +22,47 @@ use crate::{le_bytes_i32, Vars};
 pub struct BenchOpts {
     /// Only time whole programs, for low-cost checks without an activity tracer
     #[arg(long)]
-    pub program_only: bool,
+    program_only: bool,
     /// Only run hardware probes (useful for independent profiler validation)
     #[arg(long)]
-    pub calibrate_only: bool,
+    calibrate_only: bool,
     #[arg(long)]
-    pub manifest: Option<PathBuf>,
+    manifest: Option<PathBuf>,
     #[arg(long)]
-    pub kernels: Option<PathBuf>,
+    kernels: Option<PathBuf>,
     #[arg(long)]
-    pub weights: Vec<PathBuf>,
+    weights: Vec<PathBuf>,
     #[arg(long)]
-    pub tokenizer: Option<PathBuf>,
+    tokenizer: Option<PathBuf>,
     #[arg(long)]
-    pub gpu: Option<usize>,
+    gpu: Option<usize>,
     /// Scenario list, sample count and seed; independent of the model ABI
     #[arg(long)]
-    pub workload: PathBuf,
+    workload: PathBuf,
     /// Portable JSON with raw samples and all call locations; no machine paths
     #[arg(long)]
-    pub out: PathBuf,
+    out: PathBuf,
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct Scenario {
-    pub id: String,
-    pub kind: String,
-    pub batch: usize,
-    pub query: usize,
+    id: String,
+    kind: String,
+    batch: usize,
+    query: usize,
     /// One previous-context length per sequence, or one broadcast length
-    pub context: Vec<usize>,
+    context: Vec<usize>,
     #[serde(default)]
-    pub holdout: bool,
+    holdout: bool,
 }
 
 #[derive(Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Workload {
-    pub samples: usize,
-    pub seed: u64,
-    pub scenarios: Vec<Scenario>,
+    samples: usize,
+    seed: u64,
+    scenarios: Vec<Scenario>,
 }
 
 impl Scenario {
@@ -81,19 +81,19 @@ impl Scenario {
 
 #[derive(Serialize, Debug)]
 pub struct Stats {
-    pub n: usize,
-    pub min: f64,
-    pub p10: f64,
-    pub p50: f64,
-    pub p90: f64,
-    pub max: f64,
-    pub mean: f64,
-    pub cv: f64,
-    pub tail_ratio: f64,
-    pub block_medians: Vec<f64>,
+    n: usize,
+    min: f64,
+    p10: f64,
+    p50: f64,
+    p90: f64,
+    max: f64,
+    mean: f64,
+    cv: f64,
+    tail_ratio: f64,
+    block_medians: Vec<f64>,
 }
 
-pub fn stats(samples: &[f64]) -> Stats {
+fn stats(samples: &[f64]) -> Stats {
     assert!(!samples.is_empty() && samples.iter().all(|x| x.is_finite() && *x >= 0.));
     let mut v = samples.to_vec();
     v.sort_by(f64::total_cmp);

--- a/crates/kern-run/src/config.rs
+++ b/crates/kern-run/src/config.rs
@@ -41,16 +41,16 @@ use serde::Deserialize;
 #[derive(Deserialize, Debug, Default, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct Config {
-    pub gpu: Option<usize>,
-    pub capacity: Option<u64>,
+    pub(crate) gpu: Option<usize>,
+    pub(crate) capacity: Option<u64>,
     #[serde(default)]
     pub targets: BTreeMap<String, Target>,
     #[serde(default)]
     pub kernels: Kernels,
     #[serde(default)]
-    pub test: Test,
+    pub(crate) test: Test,
     #[serde(default)]
-    pub run: Run,
+    pub(crate) run: Run,
     /// Where the file was found.
     #[serde(skip)]
     pub path: PathBuf,
@@ -63,8 +63,8 @@ pub struct Target {
     pub reference: Option<PathBuf>,
     pub kernels: PathBuf,
     #[serde(default)]
-    pub weights: Vec<PathBuf>,
-    pub tokenizer: Option<PathBuf>,
+    pub(crate) weights: Vec<PathBuf>,
+    pub(crate) tokenizer: Option<PathBuf>,
 }
 
 #[derive(Deserialize, Debug, Default, Clone)]
@@ -78,22 +78,22 @@ pub struct Kernels {
 #[derive(Deserialize, Debug, Default, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct Test {
-    pub seed: Option<u64>,
-    pub decode_steps: Option<u64>,
-    pub logit_ulp: Option<u64>,
-    pub fuzz: Option<usize>,
-    pub prompt: Option<String>,
+    pub(crate) seed: Option<u64>,
+    pub(crate) decode_steps: Option<u64>,
+    pub(crate) logit_ulp: Option<u64>,
+    pub(crate) fuzz: Option<usize>,
+    pub(crate) prompt: Option<String>,
 }
 
 #[derive(Deserialize, Debug, Default, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct Run {
-    pub prompt: Option<String>,
-    pub steps: Option<usize>,
-    pub chunk: Option<u64>,
+    pub(crate) prompt: Option<String>,
+    pub(crate) steps: Option<usize>,
+    pub(crate) chunk: Option<u64>,
 }
 
-pub const FILE: &str = "kern.toml";
+pub(crate) const FILE: &str = "kern.toml";
 
 impl Config {
     /// The nearest `kern.toml` at or above the cwd, or the one given.
@@ -113,7 +113,7 @@ impl Config {
         }
     }
 
-    pub fn load(path: &Path) -> Result<Config> {
+    fn load(path: &Path) -> Result<Config> {
         let text = std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
         let mut c: Config = toml::from_str(&text).with_context(|| format!("{}", path.display()))?;
         c.path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());

--- a/crates/kern-run/src/lib.rs
+++ b/crates/kern-run/src/lib.rs
@@ -38,11 +38,11 @@ pub static VERSION: LazyLock<String> = LazyLock::new(|| {
 /// union in order; a bare .safetensors file carries neither.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct Checkpoint {
-    pub tokenizer: Option<std::path::PathBuf>,
-    pub stop_tokens: Vec<i64>,
+    tokenizer: Option<std::path::PathBuf>,
+    stop_tokens: Vec<i64>,
 }
 
-pub fn checkpoint(paths: &[std::path::PathBuf]) -> Checkpoint {
+fn checkpoint(paths: &[std::path::PathBuf]) -> Checkpoint {
     let mut c = Checkpoint::default();
     for d in paths.iter().filter(|p| p.is_dir()) {
         let t = d.join("tokenizer.json");
@@ -86,7 +86,7 @@ pub fn le_bytes_i32(v: &[i32]) -> Vec<u8> {
 }
 
 /// The var vars of one call.
-pub type Vars = BTreeMap<String, u64>;
+pub(crate) type Vars = BTreeMap<String, u64>;
 
 /// The safetensors a `--weights` entry stands for: the file itself, or
 /// every `*.safetensors` under a directory (a checkpoint's shards) in
@@ -123,17 +123,17 @@ fn map_file(f: &std::path::Path) -> Result<memmap2::Mmap> {
 /// order (one for a decode step or a prefill chunk, `count` of `rows` for
 /// a speculative round).
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Emitted(pub Vec<i64>);
+pub struct Emitted(Vec<i64>);
 
 /// A runtime plus the single sequence: its token slots and position cursor.
-pub struct Caller {
-    pub rt: Runtime,
-    pub protocol: Protocol,
+pub(crate) struct Caller {
+    rt: Runtime,
+    protocol: Protocol,
     /// The sequence's slots: as many as one page-table row (or the whole
     /// state) holds, leased once for the caller's life.
     lease: Lease,
     /// Tokens already in the state (next slot to fill).
-    pub pos: i64,
+    pos: i64,
 }
 
 impl Caller {
@@ -142,7 +142,7 @@ impl Caller {
     /// caller is sequence 0, but every row must hold valid page ids. Line
     /// tables of a per-sequence state likewise get this sequence's lines
     /// in every column, in entry 0 of a wide cell.
-    pub fn new(mut rt: Runtime) -> Result<Caller> {
+    fn new(mut rt: Runtime) -> Result<Caller> {
         let protocol = Protocol::check(&rt.manifest)?;
         let lease = rt.lease(rt.max_seq_tokens().min(rt.capacity() as usize))?;
         for t in &protocol.page_tables {
@@ -171,14 +171,14 @@ impl Caller {
     }
 
     /// Token slots the sequence can hold.
-    pub fn limit(&self) -> usize {
+    fn limit(&self) -> usize {
         self.lease.tokens()
     }
 
     /// Stage one call's rows at the cursor: `ids` as consecutive positions
     /// of this one sequence, in every fill the manifest declares. Does not
     /// advance. Returns the call's var vars.
-    pub fn stage(&mut self, ids: &[i64]) -> Result<Vars> {
+    fn stage(&mut self, ids: &[i64]) -> Result<Vars> {
         let c = ids.len();
         let pos = self.pos as usize;
         let e = self.protocol.vars(1, c as u64, c as u64);
@@ -204,21 +204,21 @@ impl Caller {
     /// token, in row 0 and again in every other row. A program that
     /// drafts its own rows (a speculative round) overwrites rows 1.. on
     /// the device; a one-row step reads only row 0.
-    pub fn stage_rows(&mut self, tok: i64, rows: u64) -> Result<Vars> {
+    fn stage_rows(&mut self, tok: i64, rows: u64) -> Result<Vars> {
         self.stage(&vec![tok; rows as usize])
     }
 
     /// Reset the cursor (a new prompt reuses the slots from position 0).
-    pub fn reset(&mut self) {
+    fn reset(&mut self) {
         self.pos = 0;
     }
 
-    pub fn advance(&mut self, n: u64) {
+    fn advance(&mut self, n: u64) {
         self.pos += n as i64;
     }
 
     /// The forward for one sequence of `rows` rows per call.
-    pub fn forward(&self, rows: Rows) -> Result<Forward> {
+    fn forward(&self, rows: Rows) -> Result<Forward> {
         self.protocol.forward(1, rows).cloned().ok_or_else(|| {
             anyhow::anyhow!(
                 "no program takes one sequence of {} rows; the manifest declares rows {:?}{}",
@@ -233,7 +233,7 @@ impl Caller {
     }
 
     /// The program a chunk of the prompt goes through.
-    pub fn chunk_forward(&self) -> Result<Forward> {
+    fn chunk_forward(&self) -> Result<Forward> {
         self.forward(Rows::Var)
     }
 
@@ -241,7 +241,7 @@ impl Caller {
     /// advancing the cursor past them. Returns the token the last chunk
     /// handed back, if the chunk program emits one, and whether a graph
     /// was captured.
-    pub fn prefill(&mut self, ids: &[i64], chunk: u64) -> Result<Option<i64>> {
+    fn prefill(&mut self, ids: &[i64], chunk: u64) -> Result<Option<i64>> {
         let f = self.chunk_forward()?;
         let mut last = None;
         let mut i = 0usize;
@@ -258,7 +258,7 @@ impl Caller {
     }
 
     /// Vocabulary size as declared by the token fill's domain (1000 if none).
-    pub fn vocab(&self) -> u64 {
+    fn vocab(&self) -> u64 {
         let m = &self.rt.manifest;
         m.buffers[&self.protocol.token_rows().name]
             .domain
@@ -270,7 +270,7 @@ impl Caller {
 
     /// What the last run of `f` handed back for this sequence: its `tokens`
     /// output's first cell, cut to its `count` (one without a count).
-    pub fn emitted(&self, f: &Forward) -> Result<Emitted> {
+    fn emitted(&self, f: &Forward) -> Result<Emitted> {
         let Some(i) = f.emits else { return Ok(Emitted(Vec::new())) };
         let t = &self.protocol.fills[i];
         let mut v = t.decode(&self.rt.read_output(&t.name)?);

--- a/crates/kern-run/src/run.rs
+++ b/crates/kern-run/src/run.rs
@@ -30,58 +30,58 @@ use tracing::info;
 pub struct RunOpts {
     /// Manifest JSON (must pass verification)
     #[arg(long)]
-    pub manifest: Option<PathBuf>,
+    manifest: Option<PathBuf>,
 
     /// Directory of cubins; steps resolve by their pinned sha256, so one dir
     /// holds every version (file names are labels)
     #[arg(long)]
-    pub kernels: Option<PathBuf>,
+    kernels: Option<PathBuf>,
 
     /// Safetensors artifact(s), tensors bound by name across all of them
     #[arg(long)]
-    pub weights: Vec<PathBuf>,
+    weights: Vec<PathBuf>,
 
     /// HF tokenizer.json
     #[arg(long)]
-    pub tokenizer: Option<PathBuf>,
+    tokenizer: Option<PathBuf>,
 
     /// Raw (template-free) prompt
     #[arg(long)]
-    pub prompt: Option<String>,
+    prompt: Option<String>,
 
     /// Max new tokens to generate
     #[arg(long)]
-    pub steps: Option<usize>,
+    steps: Option<usize>,
 
     /// CUDA device ordinal
     #[arg(long)]
-    pub gpu: Option<usize>,
+    gpu: Option<usize>,
 
     /// State capacity in tokens (KV pages etc.); rounded down to the
     /// manifest's page unit. Default: what one sequence can reach (the
     /// manifest's page-table row)
     #[arg(long)]
-    pub capacity: Option<u64>,
+    capacity: Option<u64>,
 
     /// Prefill chunk in tokens: the manifest's `tokens` bound unless a
     /// smaller one is asked for
     #[arg(long)]
-    pub chunk: Option<u64>,
+    chunk: Option<u64>,
 
     /// Debug: launch every program eagerly, ignoring the manifest's `graph`
     #[arg(long)]
-    pub eager: bool,
+    eager: bool,
 
     /// Rows per sequence of a decode step: a shape some program of the
     /// manifest declares (1 for a plain step, its block for a speculative
     /// round). Default: the widest declared
     #[arg(long)]
-    pub rows: Option<u64>,
+    rows: Option<u64>,
 
     /// Extra token ids that end generation (comma-separated); the eos ids
     /// the checkpoint declares in generation_config.json always apply
     #[arg(long, value_delimiter = ',')]
-    pub stop_tokens: Vec<i64>,
+    stop_tokens: Vec<i64>,
 
     /// Debug: dump activations of the first prefill chunk and `--probe-steps`
     /// decode steps into this directory, then exit: after every call whose
@@ -89,15 +89,15 @@ pub struct RunOpts {
     /// plus the logits the step's tokens are taken from and the tokens.
     /// Programs run call-range by call-range so nothing executes twice.
     #[arg(long)]
-    pub probe_dir: Option<PathBuf>,
+    probe_dir: Option<PathBuf>,
     /// Call labels `--probe-dir` dumps after: comma-separated, a label
     /// matches one it equals or ends with (the file is named by the label
     /// minus its last `.part`)
     #[arg(long, default_value = "embed,.down_proj")]
-    pub probe_labels: String,
+    probe_labels: String,
     /// Decode steps `--probe-dir` dumps
     #[arg(long, default_value_t = 2)]
-    pub probe_steps: usize,
+    probe_steps: usize,
 }
 
 /// Resolved options: flag, else kern.toml, else default.

--- a/crates/kern-run/src/test.rs
+++ b/crates/kern-run/src/test.rs
@@ -57,81 +57,81 @@ pub struct TestOpts {
     pub reference: Option<PathBuf>,
     /// Candidate manifest B
     #[arg(long)]
-    pub manifest: Option<PathBuf>,
+    manifest: Option<PathBuf>,
     /// Directory of cubins for both manifests; steps resolve by their pinned
     /// sha256, so one dir holds every version (file names are labels)
     #[arg(long)]
-    pub kernels: Option<PathBuf>,
+    kernels: Option<PathBuf>,
     /// Safetensors artifact(s), tensors bound by name across all of them
     #[arg(long)]
-    pub weights: Vec<PathBuf>,
+    weights: Vec<PathBuf>,
     /// HF tokenizer.json (only needed with --prompt)
     #[arg(long)]
-    pub tokenizer: Option<PathBuf>,
+    tokenizer: Option<PathBuf>,
     /// Real-text prompt for the tap's prefill instead of seeded random
     /// tokens (decode tokens stay seeded)
     #[arg(long)]
-    pub prompt: Option<String>,
+    prompt: Option<String>,
     /// Prefill length in tokens; 0 = drawn from the seed: half the time
     /// uniform in [1, capacity − steps], half the time a structural
     /// boundary (a page, a chunk, the `tokens` max, ±1)
     #[arg(long, default_value_t = 0)]
-    pub prefill: u64,
+    prefill: u64,
     /// Decode steps; the seed picks a length in [steps/2, steps] (default 32)
     #[arg(long)]
-    pub decode_steps: Option<u64>,
+    decode_steps: Option<u64>,
     /// How far the end-to-end logits may move, in ulps at the row's scale
     /// (A's max |logit|), and still PASS (with logit evidence), provided
     /// the argmax agrees except at near-ties (default 4)
     #[arg(long)]
-    pub logit_ulp: Option<u64>,
+    logit_ulp: Option<u64>,
     /// Fuzz rounds per cut (0 disables); rounds cycle through the
     /// perturbations of the tapped inputs (jitter, noise, scale, shuffle,
     /// resample, outliers) (default 6)
     #[arg(long)]
-    pub fuzz: Option<usize>,
+    fuzz: Option<usize>,
     /// CUDA device ordinal (default 0)
     #[arg(long)]
-    pub gpu: Option<usize>,
+    gpu: Option<usize>,
     /// State capacity in tokens; rounded down to the manifest's page unit
     /// (default 4096)
     #[arg(long)]
-    pub capacity: Option<u64>,
+    capacity: Option<u64>,
     /// Prefill chunk; 0 = drawn from the seed among the `tokens` max, 512,
     /// a page and a random size
     #[arg(long, default_value_t = 0)]
-    pub chunk: u64,
+    chunk: u64,
     /// Replays for cut timing (minimum is reported)
     #[arg(long, default_value_t = 20)]
-    pub iters: usize,
+    iters: usize,
     /// Skip capturing both decode programs as CUDA graphs for the step time
     #[arg(long)]
-    pub no_graph_step: bool,
+    no_graph_step: bool,
     /// Skip sweeping prefill over the `tokens` var range
     #[arg(long)]
-    pub no_sweep: bool,
+    no_sweep: bool,
     /// Device peak memory bandwidth in GB/s, for the roofline column
     #[arg(long, default_value_t = 8000.0)]
-    pub peak_bw: f64,
+    peak_bw: f64,
     /// Write the test report as JSON here (a directory when several
     /// targets run: one file per target)
     #[arg(long)]
-    pub out: Option<PathBuf>,
+    out: Option<PathBuf>,
     /// Only print the structural diff
     #[arg(long)]
-    pub diff_only: bool,
+    diff_only: bool,
     /// Skip the timing section
     #[arg(long)]
-    pub no_perf: bool,
+    no_perf: bool,
     /// Skip the noise-floor re-runs
     #[arg(long)]
-    pub no_noise: bool,
+    no_noise: bool,
     /// Seed for the workload and the fuzz generator (default 0x5eed)
     #[arg(long)]
-    pub seed: Option<u64>,
+    seed: Option<u64>,
     /// Print the report as one JSON object instead of text lines
     #[arg(long)]
-    pub json: bool,
+    json: bool,
 }
 
 /// Resolved options: flag, else kern.toml, else default.

--- a/crates/kern-runtime/src/device.rs
+++ b/crates/kern-runtime/src/device.rs
@@ -19,8 +19,8 @@ use crate::error::{bail, cuda_check, Error, Result};
 /// importer must map in full.
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub struct PeerHandle {
-    pub fabric: [u8; 64],
-    pub bytes: u64,
+    fabric: [u8; 64],
+    pub(crate) bytes: u64,
 }
 
 impl PeerHandle {

--- a/crates/kern-runtime/src/exec.rs
+++ b/crates/kern-runtime/src/exec.rs
@@ -69,7 +69,7 @@ impl Runtime {
     /// waiting. Ranks whose kernels wait on each other (an EP dispatch, a
     /// tray collective) must all be issued before any is waited for:
     /// `enqueue` each, then [`Runtime::synchronize`] each.
-    pub fn enqueue(&self, program: &str, vars: &BTreeMap<String, u64>) -> Result<()> {
+    fn enqueue(&self, program: &str, vars: &BTreeMap<String, u64>) -> Result<()> {
         let Some(prog) = self.programs.get(program) else {
             bail!(Api, "no program `{program}`");
         };
@@ -167,7 +167,7 @@ impl Runtime {
 
     /// Launch a previously captured program's graph without waiting (see
     /// [`Runtime::enqueue`]).
-    pub fn enqueue_captured(&self, program: &str, vars: &BTreeMap<String, u64>) -> Result<()> {
+    fn enqueue_captured(&self, program: &str, vars: &BTreeMap<String, u64>) -> Result<()> {
         let exec = self.graph(program, vars)?;
         self.ctx.bind_to_thread()?;
         cuda_check(unsafe { sys::cuGraphLaunch(exec, self.stream.cu_stream()) }, "cuGraphLaunch")

--- a/crates/kern-runtime/src/harness.rs
+++ b/crates/kern-runtime/src/harness.rs
@@ -152,16 +152,10 @@ impl Runtime {
         Ok(())
     }
 
-    /// Per-call GPU time in ms (eager, event-bracketed), minimum over
-    /// `iters` replays of the whole program. Note this attributes launch
-    /// gaps to the call that follows them.
-    pub fn time_calls(&self, program: &str, vars: &BTreeMap<String, u64>, iters: usize) -> Result<Vec<f32>> {
-        let n = self.call_count(program)?;
-        self.time_range(program, vars, 0, n, iters)
-    }
-
-    /// Same, for calls `[lo, hi)` only — replaying just that range, so
-    /// a cut can be timed without the rest of the program.
+    /// Per-call GPU time in ms (eager, event-bracketed) for calls
+    /// `[lo, hi)`, minimum over `iters` replays of just that range, so a
+    /// cut can be timed without the rest of the program. Note this
+    /// attributes launch gaps to the call that follows them.
     pub fn time_range(
         &self,
         program: &str,

--- a/crates/kern-runtime/src/host.rs
+++ b/crates/kern-runtime/src/host.rs
@@ -199,7 +199,7 @@ impl Parked {
     }
 
     /// Whether any page is held (a slot-only checkpoint parks its slot alone).
-    pub fn paged(&self) -> bool {
+    pub(crate) fn paged(&self) -> bool {
         self.chain.is_some()
     }
 

--- a/crates/kern-runtime/src/lib.rs
+++ b/crates/kern-runtime/src/lib.rs
@@ -199,7 +199,7 @@ impl Runtime {
     /// Check `data` (a prefix of buffer `name`) against the buffer's declared
     /// domain, if any, at the given var values. Symbol-dependent bounds
     /// need `vars`; pass the values the next run will use.
-    pub fn check_domain(&self, name: &str, data: &[u8], vars: &BTreeMap<String, u64>) -> Result<()> {
+    fn check_domain(&self, name: &str, data: &[u8], vars: &BTreeMap<String, u64>) -> Result<()> {
         let Some(b) = self.manifest.buffers.get(name) else {
             bail!(Api, "no buffer `{name}`");
         };
@@ -333,7 +333,7 @@ impl Runtime {
 /// Device memory left untouched when the states are fitted to the device:
 /// the driver's own allocations after load (captured graphs, module
 /// lazy-loading, cuBLASLt algorithm state) and a margin for a neighbour.
-pub const HEADROOM: u64 = 1 << 30;
+pub(crate) const HEADROOM: u64 = 1 << 30;
 
 /// Tokens one sequence of `m` can reach — the narrowest page table's row,
 /// in whole pages — or `None` when nothing is paged per token. What a

--- a/crates/kern-runtime/src/pages.rs
+++ b/crates/kern-runtime/src/pages.rs
@@ -529,7 +529,7 @@ impl Pool {
     }
 
     /// Whether any remap was ever planned: the initial layout is gone.
-    pub fn remapped(&self) -> bool {
+    pub(crate) fn remapped(&self) -> bool {
         lock(&self.inner).remapped
     }
 

--- a/crates/kern-runtime/src/prefix.rs
+++ b/crates/kern-runtime/src/prefix.rs
@@ -180,7 +180,7 @@ pub struct Chain {
 }
 
 impl Chain {
-    pub fn new(unit: usize) -> Chain {
+    fn new(unit: usize) -> Chain {
         assert!(unit >= 1);
         Chain { unit, heads: vec![SEED], tail: SEED, len: 0 }
     }
@@ -202,10 +202,6 @@ impl Chain {
 
     pub fn extend(&mut self, tokens: impl IntoIterator<Item = i64>) {
         tokens.into_iter().for_each(|t| self.push(t));
-    }
-
-    pub fn len(&self) -> usize {
-        self.len
     }
 
     pub fn is_empty(&self) -> bool {
@@ -452,7 +448,7 @@ mod tests {
                 assert_eq!(grown, Chain::over(unit, &tokens[..i]));
                 grown.push(t);
             }
-            assert_eq!((grown.len(), &grown), (n, &Chain::over(unit, &tokens)));
+            assert_eq!((grown.len, &grown), (n, &Chain::over(unit, &tokens)));
             for len in 0..=n {
                 let short = Chain::over(unit, &tokens[..len]);
                 let expected = (len.is_multiple_of(unit) || len == n).then(|| short.key(len).unwrap());


### PR DESCRIPTION
Follow-up to #7: the cleanup pass over what hawk reports.

**What changed.** Every `pub` that nothing outside its crate reaches is now `pub(crate)` or private (129 declarations across kern-manifest, kern-run, kern-runtime). Two unreached items are deleted: `Chain::len` (its only caller was a unit test, which now reads the field) and `Runtime::time_calls` (its doc moved onto `time_range`).

**How the kern-serve boundary was drawn.** hawk's `--fix` was applied wholesale, then kern-serve was built against the result in kernel-lab. It needed exactly four items back: `eos_ids`, `le_bytes_i32`, `Chain::push`, `Runtime::pending_peers`. Those stay `pub`. The 14 `dead_public` findings hawk still reports are all `Runtime` methods kern-serve drives (`lease_slot`, `retire`, `landed`, `pages_used`, …), which hawk cannot see because kern-serve is outside the workspace.

**Gate.**

| check | result |
|---|---|
| `cargo +1.98.1 hawk check` | 18 findings, all kern-serve's API |
| CI lint set (`-D unnecessary_restricted_visibility`) | 0 |
| kern-serve `cargo check --all-targets` (kernel-lab) | clean |
| workspace `clippy -D warnings`, tests, fmt | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011gx2qCRJKiKHGejgh7GtEK