### PR TITLE
kern-serve: pin pegainfer 139d925e with tool argument fallback

### DIFF
--- a/crates/kern-serve/Cargo.lock
+++ b/crates/kern-serve/Cargo.lock
@@ -2675,7 +2675,7 @@ dependencies = [
 [[package]]
 name = "pegainfer-frontend"
 version = "0.1.0"
-source = "git+https://github.com/pegainfer-project/pegainfer?rev=a30543d10c21b713895ec317366729c9cd12cea3#a30543d10c21b713895ec317366729c9cd12cea3"
+source = "git+https://github.com/pegainfer-project/pegainfer?rev=139d925e8693dcff412b8501f8db09eb639d0ffd#139d925e8693dcff412b8501f8db09eb639d0ffd"
 dependencies = [
  "anyhow",
  "axum",
@@ -5041,12 +5041,12 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "vllm-build-info"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=6ff479e1f798048829f884b4229f28c9b9b0c8d7#6ff479e1f798048829f884b4229f28c9b9b0c8d7"
+source = "git+https://github.com/vllm-project/vllm.git?rev=89dbb2644552d6e473a7e97da0ce8f0aa8e32c9d#89dbb2644552d6e473a7e97da0ce8f0aa8e32c9d"
 
 [[package]]
 name = "vllm-chat"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=6ff479e1f798048829f884b4229f28c9b9b0c8d7#6ff479e1f798048829f884b4229f28c9b9b0c8d7"
+source = "git+https://github.com/vllm-project/vllm.git?rev=89dbb2644552d6e473a7e97da0ce8f0aa8e32c9d#89dbb2644552d6e473a7e97da0ce8f0aa8e32c9d"
 dependencies = [
  "anyhow",
  "asynk-strim-attr",
@@ -5084,7 +5084,7 @@ dependencies = [
 [[package]]
 name = "vllm-engine-core-client"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=6ff479e1f798048829f884b4229f28c9b9b0c8d7#6ff479e1f798048829f884b4229f28c9b9b0c8d7"
+source = "git+https://github.com/vllm-project/vllm.git?rev=89dbb2644552d6e473a7e97da0ce8f0aa8e32c9d#89dbb2644552d6e473a7e97da0ce8f0aa8e32c9d"
 dependencies = [
  "arc-swap",
  "bytemuck",
@@ -5118,7 +5118,7 @@ dependencies = [
 [[package]]
 name = "vllm-llm"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=6ff479e1f798048829f884b4229f28c9b9b0c8d7#6ff479e1f798048829f884b4229f28c9b9b0c8d7"
+source = "git+https://github.com/vllm-project/vllm.git?rev=89dbb2644552d6e473a7e97da0ce8f0aa8e32c9d#89dbb2644552d6e473a7e97da0ce8f0aa8e32c9d"
 dependencies = [
  "easy-ext",
  "enum-as-inner",
@@ -5138,7 +5138,7 @@ dependencies = [
 [[package]]
 name = "vllm-metrics"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=6ff479e1f798048829f884b4229f28c9b9b0c8d7#6ff479e1f798048829f884b4229f28c9b9b0c8d7"
+source = "git+https://github.com/vllm-project/vllm.git?rev=89dbb2644552d6e473a7e97da0ce8f0aa8e32c9d#89dbb2644552d6e473a7e97da0ce8f0aa8e32c9d"
 dependencies = [
  "itertools",
  "prometheus-client",
@@ -5147,7 +5147,7 @@ dependencies = [
 [[package]]
 name = "vllm-parser"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=6ff479e1f798048829f884b4229f28c9b9b0c8d7#6ff479e1f798048829f884b4229f28c9b9b0c8d7"
+source = "git+https://github.com/vllm-project/vllm.git?rev=89dbb2644552d6e473a7e97da0ce8f0aa8e32c9d#89dbb2644552d6e473a7e97da0ce8f0aa8e32c9d"
 dependencies = [
  "easy-ext",
  "serde",
@@ -5160,9 +5160,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "vllm-proto"
+version = "0.1.0"
+source = "git+https://github.com/vllm-project/vllm.git?rev=89dbb2644552d6e473a7e97da0ce8f0aa8e32c9d#89dbb2644552d6e473a7e97da0ce8f0aa8e32c9d"
+dependencies = [
+ "prost",
+ "prost-types",
+ "protox",
+ "tonic",
+ "tonic-prost",
+ "tonic-prost-build",
+]
+
+[[package]]
 name = "vllm-server"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=6ff479e1f798048829f884b4229f28c9b9b0c8d7#6ff479e1f798048829f884b4229f28c9b9b0c8d7"
+source = "git+https://github.com/vllm-project/vllm.git?rev=89dbb2644552d6e473a7e97da0ce8f0aa8e32c9d#89dbb2644552d6e473a7e97da0ce8f0aa8e32c9d"
 dependencies = [
  "anyhow",
  "asynk-strim-attr",
@@ -5178,9 +5191,7 @@ dependencies = [
  "libc",
  "llm-multimodal",
  "openssl",
- "prost",
  "prost-types",
- "protox",
  "rmpv",
  "serde",
  "serde_json",
@@ -5197,8 +5208,6 @@ dependencies = [
  "tokio-util",
  "tonic",
  "tonic-health",
- "tonic-prost",
- "tonic-prost-build",
  "tower",
  "tower-http",
  "tracing",
@@ -5212,13 +5221,14 @@ dependencies = [
  "vllm-engine-core-client",
  "vllm-llm",
  "vllm-metrics",
+ "vllm-proto",
  "vllm-text",
 ]
 
 [[package]]
 name = "vllm-text"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=6ff479e1f798048829f884b4229f28c9b9b0c8d7#6ff479e1f798048829f884b4229f28c9b9b0c8d7"
+source = "git+https://github.com/vllm-project/vllm.git?rev=89dbb2644552d6e473a7e97da0ce8f0aa8e32c9d#89dbb2644552d6e473a7e97da0ce8f0aa8e32c9d"
 dependencies = [
  "anyhow",
  "asynk-strim-attr",
@@ -5243,7 +5253,7 @@ dependencies = [
 [[package]]
 name = "vllm-tokenizer"
 version = "0.1.0"
-source = "git+https://github.com/vllm-project/vllm.git?rev=6ff479e1f798048829f884b4229f28c9b9b0c8d7#6ff479e1f798048829f884b4229f28c9b9b0c8d7"
+source = "git+https://github.com/vllm-project/vllm.git?rev=89dbb2644552d6e473a7e97da0ce8f0aa8e32c9d#89dbb2644552d6e473a7e97da0ce8f0aa8e32c9d"
 dependencies = [
  "base64 0.22.1",
  "fastokens",

--- a/crates/kern-serve/Cargo.toml
+++ b/crates/kern-serve/Cargo.toml
@@ -24,7 +24,7 @@ kern-runtime = { path = "../kern-runtime" }
 kern-run = { path = "../kern-run" }
 # Pinned to a pegainfer main commit; bump deliberately. Its vLLM crates carry
 # the chat renderers, picked by the checkpoint's model_type.
-pegainfer-frontend = { git = "https://github.com/pegainfer-project/pegainfer", rev = "a30543d10c21b713895ec317366729c9cd12cea3" }
+pegainfer-frontend = { git = "https://github.com/pegainfer-project/pegainfer", rev = "139d925e8693dcff412b8501f8db09eb639d0ffd" }
 
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
@@ -42,4 +42,4 @@ path = "src/main.rs"
 
 [dev-dependencies]
 # The same vLLM rev pegainfer pins, so the renderer tests read the crate the server runs.
-vllm-chat = { git = "https://github.com/vllm-project/vllm.git", rev = "6ff479e1f798048829f884b4229f28c9b9b0c8d7" }
+vllm-chat = { git = "https://github.com/vllm-project/vllm.git", rev = "89dbb2644552d6e473a7e97da0ce8f0aa8e32c9d" }

--- a/crates/kern-serve/tests/renderer.rs
+++ b/crates/kern-serve/tests/renderer.rs
@@ -12,9 +12,6 @@ fn native_nonthinking_user_prompt_matches_supplied_v41_encoding() {
     assert_eq!(actual, "<｜begin▁of▁sentence｜><｜User｜>Hello.<｜Assistant｜></think>");
 }
 
-/// Fixture cases whose reference output upstream vLLM does not reproduce.
-const UPSTREAM_REJECTS: &[&str] = &["mixed-tool-user-sorted", "invalid-json-tool-argument-fallback"];
-
 #[test]
 fn v41_matches_released_reference_text_cases() {
     use serde_json::Value;
@@ -68,21 +65,18 @@ fn v41_matches_released_reference_text_cases() {
             request.chat_options.template_kwargs.insert(key.into(), case[source].clone());
         }
         let rendered = DeepSeekV41ChatRenderer::new().render(&request);
-        // The released encoding.py decodes a tool call's arguments twice and
-        // wraps anything that is still not an object as {"arguments": raw};
-        // upstream vLLM rejects such history instead. The reference text for
-        // these two cases stays in the fixture so the divergence is visible.
-        if UPSTREAM_REJECTS.contains(&case["name"].as_str().unwrap()) {
-            assert!(rendered.is_err(), "{} is expected to be rejected by the upstream renderer", case["name"]);
-        } else if case["error"] == Value::Bool(true) {
+        if case["error"] == Value::Bool(true) {
             assert!(rendered.is_err(), "{} should fail", case["name"]);
         } else {
-            assert_eq!(
-                rendered.unwrap().prompt.into_text().unwrap(),
-                case["expected"].as_str().unwrap(),
-                "{}",
-                case["name"]
+            // The checkpoint oracle decodes double-encoded objects twice.
+            // deepseek-recipe (and vLLM #56260) instead preserves that raw
+            // string as `arguments`; keep the original fixture intact and
+            // require the rest of the rendered conversation to match it.
+            let expected = case["expected"].as_str().unwrap().replace(
+                r#"<｜DSML｜ parameter name="query" string="true">double</｜DSML｜ parameter>"#,
+                r#"<｜DSML｜ parameter name="arguments" string="true">"{\"query\":\"double\"}"</｜DSML｜ parameter>"#,
             );
+            assert_eq!(rendered.unwrap().prompt.into_text().unwrap(), expected, "{}", case["name"]);
         }
     }
 }

--- a/docs/serve.md
+++ b/docs/serve.md
@@ -18,6 +18,12 @@ API 里的模型名缺省是 manifest 的 `model`，`--served-model-name` 覆盖
 截到第一个 `{ep}`/`*` 分片段之前（`dense-tp4/r{tp}/l*.safetensors` → `dense-tp4`）。前端整个来自 pegainfer（`pegainfer-frontend`，底下是 vLLM 官方的
 Rust server crates，git dep 钉 pegainfer main 的一个 rev），kern 只贡献引擎：`crates/kern-serve`。
 
+当前钉在 pegainfer `139d925e` / vLLM `89dbb264`（2026-09-11）。包含上游 #56260：
+DSV4/V4.1 历史 tool call 的非法 JSON 或非对象参数按原文包在 `arguments` 中，不再拒绝请求。
+双重编码的对象也保留原文，不按 checkpoint 的旧 `encoding.py` 二次解码；renderer 回归测试
+保留旧 oracle fixture，只对这一处已知差异调整期望，仍比较完整对话文本。
+
+
 ## 分工
 
 - **`kern-serve::scheduler::KernScheduler`** 实现 pegainfer 的 `Scheduler`


### PR DESCRIPTION
Update kern-serve to pegainfer `139d925e` and keep its renderer test dependency on the same vLLM `89dbb264` revision. This picks up vllm-project/vllm#56260: DSV4/V4.1 assistant history with invalid JSON or non-object tool arguments is accepted and preserved verbatim.

Replace the two old renderer rejection expectations with full-conversation comparisons. Preserve the checkpoint oracle fixtures and explicitly account for deepseek-recipe's raw double-encoded argument behavior. The lockfile also picks up upstream's extracted `vllm-proto` crate. No duplicate dependency update PR is open.

Validation in the development container: locked Cargo metadata, formatting, release kern-serve tests (including all renderer fixture cases), release Clippy for all targets with warnings denied, and release binary build passed. No GPU/model evaluation was run; this update changes frontend rendering, not the runtime or model kernels.
